### PR TITLE
Release 1.4.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 
 Unreleased
 ==========
+
+1.4.1 (2022-05-13)
+==================
 * fix: All versions are shown for versionable content objects, only the latest versions for content objects should be shown.
 
 1.4.0 (2022-04-28)

--- a/djangocms_references/__init__.py
+++ b/djangocms_references/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 default_app_config = "djangocms_references.apps.ReferencesConfig"


### PR DESCRIPTION
* fix: All versions are shown for versionable content objects, only the latest versions for content objects should be shown.