### PR TITLE
Release 1.4.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 
 Unreleased
 ==========
+
+1.4.2 (2022-05-23)
+==================
 * fix: Preview link should close and open the link outside of the sideframe
 
 1.4.1 (2022-05-13)

--- a/djangocms_references/__init__.py
+++ b/djangocms_references/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 
 default_app_config = "djangocms_references.apps.ReferencesConfig"


### PR DESCRIPTION
* fix: Preview link should close and open the link outside of the sideframe