### PR TITLE
fix: URL of show references in action list of djangocms-versioning-filer list page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ py37default: &py37default
    - attach_workspace:
        at: /tmp/images
    - run: docker load -i /tmp/images/py37.tar || true
-   - run: docker run py37 tox -e $CIRCLE_STAGE
+   - run: docker run py37 tox -e $CIRCLE_JOB
 
 py38default: &py38default
   docker:
@@ -22,7 +22,7 @@ py38default: &py38default
    - attach_workspace:
        at: /tmp/images
    - run: docker load -i /tmp/images/py38.tar || true
-   - run: docker run py38 tox -e $CIRCLE_STAGE
+   - run: docker run py38 tox -e $CIRCLE_JOB
 
 py39default: &py39default
   docker:
@@ -34,7 +34,7 @@ py39default: &py39default
    - attach_workspace:
        at: /tmp/images
    - run: docker load -i /tmp/images/py39.tar || true
-   - run: docker run py39 tox -e $CIRCLE_STAGE
+   - run: docker run py39 tox -e $CIRCLE_JOB
 
 
 py37_requires: &py37_requires

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* fix: URL of `show references` in action list of djangocms-versioning-filer list page
 
 1.4.2 (2022-05-23)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ==========
 * fix: URL of `show references` in action list of djangocms-versioning-filer list page
+* fix: Added CMS_CONFIRM_VERSION4 in test_settings to show intent of using v4
+* fix: fix circleci build errors
 
 1.4.2 (2022-05-23)
 ==================

--- a/djangocms_references/templates/djangocms_versioning_filer/admin/action_buttons/show_references.html
+++ b/djangocms_references/templates/djangocms_versioning_filer/admin/action_buttons/show_references.html
@@ -2,4 +2,4 @@
 
 {% get_versioning_filer_references_url file as references_url %}
 <a href="{{ references_url }}"
-    title="{% blocktrans %}Show references{% endblocktrans %}" class="action-button"><span class="fa fa-code-fork"></span></a>
+    title="{% blocktrans %}Show references{% endblocktrans %}" class="action-button cms-form-get-method"><span class="fa fa-code-fork"></span></a>

--- a/tests/requirements/dj22_cms40.txt
+++ b/tests/requirements/dj22_cms40.txt
@@ -1,3 +1,3 @@
 -r ./requirements_base.txt
 
-Django>=2.2,<3.0
+Django>=2.2,<4.0

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -6,6 +6,6 @@ isort
 tox
 
 # Unreleased django-cms 4.0 compatible packages
-https://github.com/django-cms/django-cms/tarball/develop-4#egg=django-cms
+https://github.com/django-cms/django-cms/tarball/4.0.0#egg=django-cms
 https://github.com/django-cms/djangocms-versioning/tarball/master#egg=djangocms-versioning
 https://github.com/django-cms/djangocms-alias/tarball/master#egg=djangocms-alias

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -7,5 +7,5 @@ tox
 
 # Unreleased django-cms 4.0 compatible packages
 https://github.com/django-cms/django-cms/tarball/4.0.0#egg=django-cms
-https://github.com/django-cms/djangocms-versioning/tarball/master#egg=djangocms-versioning
-https://github.com/django-cms/djangocms-alias/tarball/master#egg=djangocms-alias
+https://github.com/django-cms/djangocms-versioning/tarball/1.2.2#egg=djangocms-versioning
+https://github.com/django-cms/djangocms-alias/tarball/1.11.0#egg=djangocms-alias

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -8,6 +8,7 @@ HELPER_SETTINGS = {
         "djangocms_references.test_utils.polls",
         "djangocms_references.test_utils.nested_references_app",
     ],
+    "CMS_CONFIRM_VERSION4": True,
     "MIGRATION_MODULES": {
         "auth": None,
         "cms": None,

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -24,7 +24,6 @@ class AliasAdminReferencesMonkeyPatchTestCase(CMSTestCase):
             language="en",
         )
 
-            
         Version.objects.create(content=alias_content, created_by=request.user)
         content_type = ContentType.objects.get(app_label=alias._meta.app_label, model=alias._meta.model_name)
         alias_admin = AliasContentAdmin(AliasContent, admin.AdminSite())

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -6,6 +6,7 @@ from cms.test_utils.testcases import CMSTestCase
 
 from djangocms_alias.admin import AliasContentAdmin
 from djangocms_alias.models import Alias, AliasContent, Category
+from djangocms_versioning.models import Version
 
 
 class AliasAdminReferencesMonkeyPatchTestCase(CMSTestCase):
@@ -22,6 +23,9 @@ class AliasAdminReferencesMonkeyPatchTestCase(CMSTestCase):
             name="Alias Reference Monkey Patch Content",
             language="en",
         )
+
+            
+        Version.objects.create(content=alias_content, created_by=request.user)
         content_type = ContentType.objects.get(app_label=alias._meta.app_label, model=alias._meta.model_name)
         alias_admin = AliasContentAdmin(AliasContent, admin.AdminSite())
         func = alias_admin.get_list_display(request)[-1]


### PR DESCRIPTION
Show-reference button in action list of versioning filer has some error, 
We can fix it by sending GET request instead of current POST request.